### PR TITLE
ESP32 compatibility

### DIFF
--- a/SDS011.cpp
+++ b/SDS011.cpp
@@ -96,6 +96,13 @@ void SDS011::wakeup() {
 	sds_data->flush();
 }
 
+#ifndef ESP32
+
+void SDS011::begin(SoftwareSerial* serial) {
+	serial->begin(9600);
+	sds_data = serial;
+}
+
 void SDS011::begin(uint8_t pin_rx, uint8_t pin_tx) {
 	_pin_rx = pin_rx;
 	_pin_tx = pin_tx;
@@ -108,13 +115,9 @@ void SDS011::begin(uint8_t pin_rx, uint8_t pin_tx) {
 	sds_data = softSerial;
 }
 
+#endif
+
 void SDS011::begin(HardwareSerial* serial) {
 	serial->begin(9600);
 	sds_data = serial;
 }
-
-void SDS011::begin(SoftwareSerial* serial) {
-	serial->begin(9600);
-	sds_data = serial;
-}
-

--- a/SDS011.h
+++ b/SDS011.h
@@ -14,15 +14,20 @@
 	#include "WProgram.h"
 #endif
 
-#include <SoftwareSerial.h>
+
+#ifndef ESP32
+	#include <SoftwareSerial.h>
+#endif
 
 
 class SDS011 {
 	public:
 		SDS011(void);
-		void begin(uint8_t pin_rx, uint8_t pin_tx);
-		void begin(HardwareSerial* serial);
+#ifndef ESP32
 		void begin(SoftwareSerial* serial);
+		void begin(uint8_t pin_rx, uint8_t pin_tx);
+#endif	
+		void begin(HardwareSerial* serial);
 		int read(float *p25, float *p10);
 		void sleep();
 		void wakeup();

--- a/examples/SDS011_HardwareSerial_ESP32/SDS011_HardwareSerial_ESP32.ino
+++ b/examples/SDS011_HardwareSerial_ESP32/SDS011_HardwareSerial_ESP32.ino
@@ -1,0 +1,33 @@
+// SDS011 dust sensor example for ESP32
+// ------------------------------------
+//
+// By R. Zschiegner (rz@madavi.de).
+// modified by S. Leiner (leiner@teco.edu)
+//
+// connect ESP32 RX pin (16) to SDS011 TX pin
+//    and  ESP32 TX pin (17) to SDS011 RX pin
+//
+// April 2016
+
+#include <SDS011.h>
+
+float p10, p25;
+int error;
+
+HardwareSerial sdsSerial(2); // use Serial 2: RX pin:16, TX pin:17
+SDS011 my_sds;
+
+void setup() {
+  sdsSerial.begin(9600);
+	my_sds.begin(&sdsSerial);
+	Serial.begin(115200);
+}
+
+void loop() {
+	error = my_sds.read(&p25, &p10);
+	if (!error) {
+		Serial.println("P2.5: " + String(p25));
+		Serial.println("P10:  " + String(p10));
+	}
+	delay(100);
+}

--- a/library.properties
+++ b/library.properties
@@ -6,4 +6,4 @@ sentence=Nova Fitness SDS011 dust sensor library
 paragraph=Nova Fitness SDS011 dust sensor library
 category=Sensors
 url=https://github.com/ricki-z/SDS011
-architectures=esp8266,avr
+architectures=esp8266,esp32,avr


### PR DESCRIPTION
This makes the library out-of-the-box compatible to the ESP32 Arduino Core.

- All uses of `SoftwareSerial` are omitted when compiling for ESP32
- A modified version of the example sketch for ESP32 is given

Tested with an ESP32 Heltec board: https://www.amazon.com/dp/B076KJZ5QM?ref=yo_pop_ma_swf