### PR TITLE
Added begin() variant to use HardwareSerial with specific RX/TX pins.

### DIFF
--- a/SDS011.cpp
+++ b/SDS011.cpp
@@ -114,6 +114,11 @@ void SDS011::begin(HardwareSerial* serial) {
 	sds_data = serial;
 }
 
+void SDS011::begin(HardwareSerial* serial, int8_t rxPin, int8_t txPin) {
+    serial->begin(9600, SERIAL_8N1, rxPin, txPin);
+    sds_data = serial;
+}
+
 #ifndef ESP32
 void SDS011::begin(SoftwareSerial* serial) {
 	serial->begin(9600);

--- a/SDS011.h
+++ b/SDS011.h
@@ -22,6 +22,7 @@ class SDS011 {
 	public:
 		SDS011(void);
 		void begin(HardwareSerial* serial);
+        void begin(HardwareSerial* serial, int8_t pin_rx, int8_t pin_tx);
 #ifndef ESP32 
 		void begin(SoftwareSerial* serial);
 		void begin(uint8_t pin_rx, uint8_t pin_tx);


### PR DESCRIPTION
I have added a variant of the Serial.begin() function that additionally takes RX/TX pins as arguments. This enables internal rewiring of pins in ESP32, which is useful to, e.g. use multiple UARTS that are not accessible otherwise. 

An example where this is of practical use is the Heltec ESP32 LoRa board (see e.g. https://www.hackerspace-ffm.de/wiki/index.php?title=Heltec_Wifi_LoRa_32). Changing the HardwareSerial pins makes the display usable while still having a UART available.